### PR TITLE
In verilog model of standard cells, fix "notifier" register definition

### DIFF
--- a/verilog/cvc-pdk/sky130_fd_sc_hd.v
+++ b/verilog/cvc-pdk/sky130_fd_sc_hd.v
@@ -36384,7 +36384,8 @@ module sky130_fd_sc_hd__dfbbn_2 (
  * SPDX-License-Identifier: Apache-2.0
 */
 
-wire AWAKE, COND0, COND1, RESETB_delayed, CLKN_delayed, notifier, D_delayed, CONDB, SETB_delayed; 
+reg notifier;
+wire AWAKE, COND0, COND1, RESETB_delayed, CLKN_delayed, D_delayed, CONDB, SETB_delayed; 
 
 specify
 ( negedge RESET_B => ( Q +: RESET_B ) ) = ( 0:0:0 ) ;   // delay is tfall
@@ -37707,7 +37708,7 @@ module sky130_fd_sc_hd__dfrbp_2 (
 
 wire RESETB_delayed; 
 wire AWAKE;
-wire notifier;
+reg notifier;
 wire D_delayed;
 wire CLK_delayed;
 wire COND1, COND0; 
@@ -38243,8 +38244,8 @@ module sky130_fd_sc_hd__dfrtn_1 (
  *
  * SPDX-License-Identifier: Apache-2.0
 */
-
-wire AWAKE, COND0, COND1, RESETB_delayed, CLKN_delayed, notifier, D_delayed; 
+reg notifier;
+wire AWAKE, COND0, COND1, RESETB_delayed, CLKN_delayed, D_delayed; 
 
 specify
 ( negedge RESET_B => ( Q +: RESET_B ) ) = ( 0:0:0 ) ;  // delay is tris
@@ -39126,7 +39127,7 @@ module sky130_fd_sc_hd__dfrtp_4 (
  *
  * SPDX-License-Identifier: Apache-2.0
 */
-
+reg notifier;
 specify
 ( negedge RESET_B => ( Q +: RESET_B ) ) = ( 0:0:0 ) ;  // delay is tris
 ( posedge CLK => ( Q : CLK ) ) = ( 0:0:0 , 0:0:0 ) ; // delays are tris , tfall
@@ -39661,7 +39662,7 @@ module sky130_fd_sc_hd__dfsbp_1 (
  *
  * SPDX-License-Identifier: Apache-2.0
 */
-
+reg notifier;
 specify
 ( negedge SET_B => ( Q -: SET_B ) ) = ( 0:0:0 ) ;  // delay is tris
 ( negedge SET_B => ( Q_N +: SET_B ) ) = ( 0:0:0 ) ;  // delay is tris
@@ -39846,7 +39847,7 @@ module sky130_fd_sc_hd__dfsbp_2 (
  *
  * SPDX-License-Identifier: Apache-2.0
 */
-
+reg notifier;
 specify
 ( negedge SET_B => ( Q -: SET_B ) ) = ( 0:0:0 ) ;  // delay is tris
 ( negedge SET_B => ( Q_N +: SET_B ) ) = ( 0:0:0 ) ;  // delay is tris
@@ -40363,7 +40364,7 @@ module sky130_fd_sc_hd__dfstp_1 (
  *
  * SPDX-License-Identifier: Apache-2.0
 */
-
+reg notifier;
 specify
 ( negedge SET_B => ( Q -: SET_B ) ) = ( 0:0:0 ) ;  // delay is tris
 ( posedge CLK => ( Q : CLK ) ) = ( 0:0:0 , 0:0:0 ) ; // delays are tris , tfall
@@ -40542,7 +40543,7 @@ module sky130_fd_sc_hd__dfstp_2 (
  *
  * SPDX-License-Identifier: Apache-2.0
 */
-
+reg notifier;
 specify
 ( negedge SET_B => ( Q -: SET_B ) ) = ( 0:0:0 ) ;  // delay is tris
 ( posedge CLK => ( Q : CLK ) ) = ( 0:0:0 , 0:0:0 ) ; // delays are tris , tfall
@@ -40721,7 +40722,7 @@ module sky130_fd_sc_hd__dfstp_4 (
  *
  * SPDX-License-Identifier: Apache-2.0
 */
-
+reg notifier;
 specify
 ( negedge SET_B => ( Q -: SET_B ) ) = ( 0:0:0 ) ;  // delay is tris
 ( posedge CLK => ( Q : CLK ) ) = ( 0:0:0 , 0:0:0 ) ; // delays are tris , tfall
@@ -41220,7 +41221,7 @@ module sky130_fd_sc_hd__dfxbp_1 (
  *
  * SPDX-License-Identifier: Apache-2.0
 */
-
+reg notifier;
 specify
 ( posedge CLK => ( Q : CLK ) ) = ( 0:0:0 , 0:0:0 ) ; // delays are tris , tfall
 ( posedge CLK => ( Q_N : CLK ) ) = ( 0:0:0 , 0:0:0 ) ; // delays are tris , tfall
@@ -41392,7 +41393,7 @@ module sky130_fd_sc_hd__dfxbp_2 (
  *
  * SPDX-License-Identifier: Apache-2.0
 */
-
+reg notifier;
 specify
 ( posedge CLK => ( Q : CLK ) ) = ( 0:0:0 , 0:0:0 ) ; // delays are tris , tfall
 ( posedge CLK => ( Q_N : CLK ) ) = ( 0:0:0 , 0:0:0 ) ; // delays are tris , tfall
@@ -41868,7 +41869,7 @@ module sky130_fd_sc_hd__dfxtp_1 (
  *
  * SPDX-License-Identifier: Apache-2.0
 */
-
+reg notifier;
 specify
 ( posedge CLK => ( Q : CLK ) ) = ( 0:0:0 , 0:0:0 ) ; // delays are tris , tfall
 $width ( posedge CLK &&& AWAKE , 1.0:1.0:1.0 , 0 , notifier ) ;
@@ -42031,7 +42032,7 @@ module sky130_fd_sc_hd__dfxtp_2 (
  *
  * SPDX-License-Identifier: Apache-2.0
 */
-
+reg notifier;
 specify
 ( posedge CLK => ( Q : CLK ) ) = ( 0:0:0 , 0:0:0 ) ; // delays are tris , tfall
 $width ( posedge CLK &&& AWAKE , 1.0:1.0:1.0 , 0 , notifier ) ;
@@ -42194,7 +42195,7 @@ module sky130_fd_sc_hd__dfxtp_4 (
  *
  * SPDX-License-Identifier: Apache-2.0
 */
-
+reg notifier;
 specify
 ( posedge CLK => ( Q : CLK ) ) = ( 0:0:0 , 0:0:0 ) ; // delays are tris , tfall
 $width ( posedge CLK &&& AWAKE , 1.0:1.0:1.0 , 0 , notifier ) ;
@@ -43021,7 +43022,7 @@ module sky130_fd_sc_hd__dlclkp_1 (
  *
  * SPDX-License-Identifier: Apache-2.0
 */
-
+reg notifier;
 specify
 ( CLK +=> GCLK ) = ( 0:0:0 , 0:0:0 ) ;                         // delays are tris , tfall
 $width ( negedge CLK &&& AWAKE , 1.0:1.0:1.0 , 0 , notifier ) ;
@@ -43183,7 +43184,7 @@ module sky130_fd_sc_hd__dlclkp_2 (
  *
  * SPDX-License-Identifier: Apache-2.0
 */
-
+reg notifier;
 specify
 ( CLK +=> GCLK ) = ( 0:0:0 , 0:0:0 ) ;                         // delays are tris , tfall
 $width ( negedge CLK &&& AWAKE , 1.0:1.0:1.0 , 0 , notifier ) ;
@@ -43344,7 +43345,7 @@ module sky130_fd_sc_hd__dlclkp_4 (
  *
  * SPDX-License-Identifier: Apache-2.0
 */
-
+reg notifier;
 specify
 ( CLK +=> GCLK ) = ( 0:0:0 , 0:0:0 ) ;                         // delays are tris , tfall
 $width ( negedge CLK &&& AWAKE , 1.0:1.0:1.0 , 0 , notifier ) ;
@@ -43892,7 +43893,7 @@ module sky130_fd_sc_hd__dlrbn_1 (
  *
  * SPDX-License-Identifier: Apache-2.0
 */
-
+reg notifier;
 specify
 ( negedge RESET_B => ( Q +: RESET_B ) ) = ( 0:0:0 , 0:0:0 ) ;  // delay is tfall
 ( D +=> Q ) = ( 0:0:0 , 0:0:0 ) ;  // delays are tris , tfall
@@ -44082,7 +44083,7 @@ module sky130_fd_sc_hd__dlrbn_2 (
  *
  * SPDX-License-Identifier: Apache-2.0
 */
-
+reg notifier;
 specify
 ( negedge RESET_B => ( Q +: RESET_B ) ) = ( 0:0:0 , 0:0:0 ) ;  // delay is tfall
 ( D +=> Q ) = ( 0:0:0 , 0:0:0 ) ;  // delays are tris , tfall
@@ -45356,7 +45357,7 @@ module sky130_fd_sc_hd__dlrtn_1 (
  *
  * SPDX-License-Identifier: Apache-2.0
 */
-
+reg notifier;
 specify
 ( negedge RESET_B => ( Q +: RESET_B ) ) = ( 0:0:0 , 0:0:0 ) ;  // delay is tfall
 ( D +=> Q ) = ( 0:0:0 , 0:0:0 ) ;  // delays are tris , tfall
@@ -45533,7 +45534,7 @@ module sky130_fd_sc_hd__dlrtn_2 (
  *
  * SPDX-License-Identifier: Apache-2.0
 */
-
+reg notifier;
 specify
 ( negedge RESET_B => ( Q +: RESET_B ) ) = ( 0:0:0 , 0:0:0 ) ;  // delay is tfall
 ( D +=> Q ) = ( 0:0:0 , 0:0:0 ) ;  // delays are tris , tfall
@@ -45711,7 +45712,7 @@ module sky130_fd_sc_hd__dlrtn_4 (
  *
  * SPDX-License-Identifier: Apache-2.0
 */
-
+reg notifier;
 specify
 ( negedge RESET_B => ( Q +: RESET_B ) ) = ( 0:0:0 , 0:0:0 ) ;  // delay is tfall
 ( D +=> Q ) = ( 0:0:0 , 0:0:0 ) ;  // delays are tris , tfall
@@ -46235,7 +46236,7 @@ module sky130_fd_sc_hd__dlrtp_1 (
  *
  * SPDX-License-Identifier: Apache-2.0
 */
-
+reg notifier;
 specify
 ( negedge RESET_B => ( Q +: RESET_B ) ) = ( 0:0:0 , 0:0:0 ) ;  // delay is tfall
 ( D +=> Q ) = ( 0:0:0 , 0:0:0 ) ;  // delays are tris , tfall
@@ -48280,7 +48281,7 @@ module sky130_fd_sc_hd__dlxtn_1 (
  *
  * SPDX-License-Identifier: Apache-2.0
 */
-
+reg notifier;
 specify
 ( D +=> Q ) = ( 0:0:0 , 0:0:0 ) ;  // delays are tris , tfall
 ( negedge GATE_N => ( Q +: D ) ) = ( 0:0:0 , 0:0:0 ) ; // delays are tris , tfall
@@ -48444,7 +48445,7 @@ module sky130_fd_sc_hd__dlxtn_2 (
  *
  * SPDX-License-Identifier: Apache-2.0
 */
-
+reg notifier;
 specify
 ( D +=> Q ) = ( 0:0:0 , 0:0:0 ) ;  // delays are tris , tfall
 ( negedge GATE_N => ( Q +: D ) ) = ( 0:0:0 , 0:0:0 ) ; // delays are tris , tfall
@@ -48609,7 +48610,7 @@ module sky130_fd_sc_hd__dlxtn_4 (
  *
  * SPDX-License-Identifier: Apache-2.0
 */
-
+reg notifier;
 specify
 ( D +=> Q ) = ( 0:0:0 , 0:0:0 ) ;  // delays are tris , tfall
 ( negedge GATE_N => ( Q +: D ) ) = ( 0:0:0 , 0:0:0 ) ; // delays are tris , tfall
@@ -66444,7 +66445,7 @@ module sky130_fd_sc_hd__lpflow_inputisolatch_1 (
  *
  * SPDX-License-Identifier: Apache-2.0
 */
-
+reg notifier;
 specify
 (D +=> Q ) = (0:0:0,0:0:0);  // delays are tris,tfall
 (posedge SLEEP_B => (Q +: D ) ) = (0:0:0,0:0:0); // delays are tris,tfall
@@ -113708,7 +113709,7 @@ module sky130_fd_sc_hd__sdfbbn_1 (
  *
  * SPDX-License-Identifier: Apache-2.0
 */
-
+reg notifier;
 specify
 ( negedge RESET_B => ( Q +: RESET_B ) ) = ( 0:0:0 ) ;   // delay is tfall
 ( negedge RESET_B => ( Q_N -: RESET_B ) ) = ( 0:0:0 ) ;  // delay is tris
@@ -114582,7 +114583,7 @@ module sky130_fd_sc_hd__sdfbbp_1 (
 */
 
 
-wire AWAKE, COND0, COND1,CONDB, COND_D, COND_SCD,COND_SCE, RESETB_delayed, CLKN_delayed,SCE_delayed,CLK_delayed, SCD_delayed, D_delayed, CONDB, SETB_delayed; 
+wire AWAKE, COND0, COND1,CONDB, COND_D, COND_SCD,COND_SCE, RESETB_delayed, CLKN_delayed,SCE_delayed,CLK_delayed, SCD_delayed, D_delayed, SETB_delayed; 
 reg notifier;
 
 specify
@@ -121330,7 +121331,7 @@ module sky130_fd_sc_hd__sdlclkp_4 (
  *
  * SPDX-License-Identifier: Apache-2.0
 */
-
+reg notifier;
 specify
 ( CLK +=> GCLK ) = ( 0:0:0 , 0:0:0 ) ;                         // delays are tris , tfall
 $setuphold ( posedge CLK , posedge SCE , 0:0:0 , 0:0:0 , notifier , SCE_AWAKE , SCE_AWAKE , CLK_delayed , SCE_delayed ) ;


### PR DESCRIPTION
Make these fixes in several places:
* In some cases, the notifier was defined as type "wire" which is invalid for some tools.
* Add the defenition of notifier in the cases where it was absent.
* Fix an issue where a wire was defined twice in the same line, which the VCS simulator didn't like.

These issues I had may have been tool-specific, but all these changes should be backwards compatible.