### PR TITLE
Added an ifdef for USE_POWER_PINS around the power pins of the SRAM in RTL verilog

### DIFF
--- a/verilog/rtl/VexRiscv_MinDebugCache.v
+++ b/verilog/rtl/VexRiscv_MinDebugCache.v
@@ -44,6 +44,10 @@
 
 
 module VexRiscv (
+`ifdef USE_POWER_PINS
+  inout      	      VPWR,
+  inout		      VGND,
+`endif
   input      [31:0]   externalResetVector,
   input               timerInterrupt,
   input               softwareInterrupt,

--- a/verilog/rtl/mgmt_core.v
+++ b/verilog/rtl/mgmt_core.v
@@ -8373,6 +8373,10 @@ always @(posedge sys_clk) begin
 end
 
 sky130_sram_2kbyte_1rw1r_32x512_8 sky130_sram_2kbyte_1rw1r_32x512_8(
+`ifdef USE_POWER_PINS
+	.vccd1(VPWR),
+	.vssd1(VGND),
+`endif
 	.addr0(sram_bus_adr[8:0]),
 	.addr1(sram_adr1),
 	.clk0(sys_clk),

--- a/verilog/rtl/mgmt_core.v
+++ b/verilog/rtl/mgmt_core.v
@@ -8425,6 +8425,10 @@ assign uart_rx_fifo_wrport_dat_r = memdat_2;
 assign uart_rx_fifo_rdport_dat_r = memdat_3;
 
 VexRiscv VexRiscv(
+`ifdef USE_POWER_PINS
+	.VPWR(VPWR),
+	.VGND(VGND),
+`endif
 	.clk(sys_clk),
 	.dBusWishbone_ACK(mgmtsoc_dbus_dbus_ack),
 	.dBusWishbone_DAT_MISO(mgmtsoc_dbus_dbus_dat_r),


### PR DESCRIPTION
Added an ifdef for USE_POWER_PINS around the power pins of the SRAM module in the RTL verilog file `mgmt_core.v` to match the verilog of the SRAM module itself.  As far as I am aware, the VexRISC core does not need the same treatment because the VexRISC core does not define power supply pins at all. Note that this is a change to an automatically-generated file, and the change needs to be made elsewhere in the LiteX code to become permanent.