### PR TITLE
Added the "constant_block" in the include

### DIFF
--- a/verilog/includes/includes.rtl.caravel
+++ b/verilog/includes/includes.rtl.caravel
@@ -39,6 +39,7 @@
 -v $(CARAVEL_PATH)/rtl/gpio_control_block.v	     
 -v $(CARAVEL_PATH)/rtl/gpio_defaults_block.v	     
 -v $(CARAVEL_PATH)/rtl/gpio_logic_high.v 	     
+-v $(CARAVEL_PATH)/rtl/constant_block.v 	     
 -v $(CARAVEL_PATH)/rtl/xres_buf.v		     
 -v $(CARAVEL_PATH)/rtl/spare_logic_block.v	     
 -v $(CARAVEL_PATH)/rtl/housekeeping.v		     
@@ -51,7 +52,7 @@
 ## These blocks are manually designed 		
 -v $(CARAVEL_PATH)/gl/gpio_defaults_block_0403.v     
 -v $(CARAVEL_PATH)/gl/gpio_defaults_block_1803.v     
-
+-v $(CARAVEL_PATH)/gl/gpio_defaults_block_0801.v
 
 # STD CELLS - they need to be below the defines.v files 
  -v $(PDK_ROOT)/$(PDK)/libs.ref/sky130_fd_io/verilog/sky130_fd_io.v


### PR DESCRIPTION
Added the "constant_block" in the include file (includes.rtl.caravel) to match the block added in the "fix_direct_power_connections" branch in the caravel repository.