### PR TITLE
cocotb - include gpio_signal_buffering module to gatelevel netlist 

### DIFF
--- a/verilog/includes/gl_caravel_vcs.list
+++ b/verilog/includes/gl_caravel_vcs.list
@@ -66,6 +66,7 @@
 -v $CARAVEL_PATH/gl/user_id_programming.v	     
 -v $CARAVEL_PATH/gl/caravel.v 		     
 -v $CARAVEL_PATH/gl/buff_flash_clkrst.v 		     
+-v $CARAVEL_PATH/gl/gpio_signal_buffering.v 		     
 
 ###########################################################
 ## These blocks are manually designed 		


### PR DESCRIPTION
include gpio_signal_buffering module to gatelevel netlist  assuming the file will exist in gl folder