### PR TITLE
Added an initialization loop to the SPI flash emulation module

### DIFF
--- a/verilog/dv/vip/spiflash.v
+++ b/verilog/dv/vip/spiflash.v
@@ -106,7 +106,14 @@ module spiflash #(
 	// 16 MB (128Mb) Flash
 	reg [7:0] memory [0:16*1024*1024-1];
 
+	integer i;
+
 	initial begin
+		// Initialize memory or else prefetch past the end of the
+		// loaded program can cause undefined values to propagate.
+		for (i=0; i < 16*1024*1024; i=i+1)
+		    memory[i] = 0;
+
 		$display("Reading %s",  FILENAME);
 		$readmemh(FILENAME, memory);
 		//$display("Memory 5 bytes = 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x",


### PR DESCRIPTION
Added an initialization loop to the SPI flash emulation module, which prevents mysterious errors caused by prefetching memory past the end of a program, resulting in undefined values propagating through the entire SoC.  Hopefully this will prevent others from wasting a lot of time tracking down the resulting non-issues in simulations.